### PR TITLE
Add optional workspace-dir input to set where the generation script runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Add the following steps to your GitHub workflow, replacing the input values:
       ]
     # Parent directory to use for generated API docs HTML
     api-docs-dir: 'YOUR_API_DOCS_FILEPATH'
+    workspace-dir: 'OPTIONAL_RELATIVE_PATH_TO_THE_OPENAPI_SCHEMA'
 ```
 
 ## Scenarios

--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
         # Used to return to caller's repository directory
         WORKSPACE_DIR: ${{ github.workspace }}
         # Used for multi-file API specs, run the script from this directory to correctly resolve relative paths in references
-        SRC_DIR: ${{ inputs.src-dir) }}
+        SRC_DIR: ${{ inputs.src-dir }}
     - name: Set up GitHub Pages
       uses: actions/configure-pages@v5
     - name: Upload API docs to GitHub Pages

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
         # Required to pass permissions to fetch OpenAPI spec files from Git branches
         GH_TOKEN: ${{ github.token }}
         # Used to return to caller's repository directory (relative workspace-dir is appended if provided)
-        WORKSPACE_DIR: ${{ join([github.workspace, inputs.workspace-dir], '/') }}
+        WORKSPACE_DIR: ${{ format('{0}/{1}', github.workspace, inputs.workspace-dir) }}
     - name: Set up GitHub Pages
       uses: actions/configure-pages@v5
     - name: Upload API docs to GitHub Pages

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,9 @@ inputs:
   api-docs-dir:
     description: Parent directory to use for API docs
     required: true
+  workspace-dir:
+    description: Optional directory to run the generation script from
+    required: false
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -55,8 +58,8 @@ runs:
         GH_ACTION_REPOSITORY: ${{ github.action_repository || github.repository }}
         # Required to pass permissions to fetch OpenAPI spec files from Git branches
         GH_TOKEN: ${{ github.token }}
-        # Used to return to caller's repository directory
-        WORKSPACE_DIR: ${{ github.workspace }}
+        # Used to return to caller's repository directory (relative workspace-dir is appended if provided)
+        WORKSPACE_DIR: ${{ join([github.workspace, inputs.workspace-dir], '/') }}
     - name: Set up GitHub Pages
       uses: actions/configure-pages@v5
     - name: Upload API docs to GitHub Pages

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
   api-docs-dir:
     description: Parent directory to use for API docs
     required: true
-  workspace-dir:
+  src-dir:
     description: Optional directory to run the generation script from
     required: false
 
@@ -58,8 +58,10 @@ runs:
         GH_ACTION_REPOSITORY: ${{ github.action_repository || github.repository }}
         # Required to pass permissions to fetch OpenAPI spec files from Git branches
         GH_TOKEN: ${{ github.token }}
-        # Used to return to caller's repository directory (relative workspace-dir is appended if provided)
-        WORKSPACE_DIR: ${{ format('{0}/{1}', github.workspace, inputs.workspace-dir) }}
+        # Used to return to caller's repository directory
+        WORKSPACE_DIR: ${{ github.workspace }}
+        # Used for multi-file API specs, run the script from this directory to correctly resolve relative paths in references
+        SRC_DIR: ${{ inputs.src-dir) }}
     - name: Set up GitHub Pages
       uses: actions/configure-pages@v5
     - name: Upload API docs to GitHub Pages

--- a/scripts/generate-single-spec-doc.sh
+++ b/scripts/generate-single-spec-doc.sh
@@ -76,6 +76,10 @@ fullyQualifiedApiFilepath="$WORKSPACE_DIR/$API_DOCS_DIR/$apiDocFilepath"
 apiFileDir=$(dirname $fullyQualifiedApiFilepath)
 mkdir -p $apiFileDir
 echo "Generating ReDoc API docs at $fullyQualifiedApiFilepath"
+if [ -n "$SRC_DIR" ]; then
+    echo "Changing directory to SRC_DIR: $SRC_DIR"
+    cd "${SRC_DIR}"
+fi
 npx @redocly/cli build-docs $openApiYamlFilepath -o $fullyQualifiedApiFilepath
 
 if [ ! -f "$fullyQualifiedApiFilepath" ]; then

--- a/scripts/generate-single-spec-doc.sh
+++ b/scripts/generate-single-spec-doc.sh
@@ -56,6 +56,12 @@ else
         $apiSpecFetchUri > $openApiJsonFilepath
 fi
 
+# Go to the source directory if provided
+if [ -n "$SRC_DIR" ]; then
+    echo "Changing directory to SRC_DIR: $SRC_DIR"
+    cd "${SRC_DIR}"
+fi
+
 # Validate OpenAPI JSON spec exists
 if [ ! -f "$openApiJsonFilepath" ]; then
     echo "Failed to generate API documentation since API spec was not found at $openApiJsonFilepath"
@@ -76,10 +82,6 @@ fullyQualifiedApiFilepath="$WORKSPACE_DIR/$API_DOCS_DIR/$apiDocFilepath"
 apiFileDir=$(dirname $fullyQualifiedApiFilepath)
 mkdir -p $apiFileDir
 echo "Generating ReDoc API docs at $fullyQualifiedApiFilepath"
-if [ -n "$SRC_DIR" ]; then
-    echo "Changing directory to SRC_DIR: $SRC_DIR"
-    cd "${SRC_DIR}"
-fi
 npx @redocly/cli build-docs $openApiYamlFilepath -o $fullyQualifiedApiFilepath
 
 if [ ! -f "$fullyQualifiedApiFilepath" ]; then


### PR DESCRIPTION
Running the script from the repo root works fine if your OpenAPI spec is all in one file, but if [it is in separate files](https://techdocs.studio/blog/how-to-split-open-api-spec-into-multiple-files) it fails because the main schema references them relative to itself but the script is looking for them relative to the directory it's running in, which is not necessarily the same.  For example, if the schemas are in schemas.json and you include it in the main file with a file reference and their both in a docs/ directory, you'll get an error like this:

    Invalid JSON pointer: ./schemas.json#/components/schemas/something

You can solve this by moving all the OpenAPI files to the root of the repository where the script is run from but that clutters the repo root. Alternatively you can run the script from the directory the files are in so that the relative paths are correct.  For this second option users need to be able to specify a directory relative to the repo root as the base path for the OpenAPI schemas if their spec is structured this way.

The new, optional, input `workspace-dir` will be appended to the `github.workspace` path when setting the `WORKSPACE_DIR` environment variable that the generation script is already using.  This way the script will go that directory instead of the repo root and it'll be able to find the referenced files.

I wasn't able to run the tests on my laptop unfortunately so I can't guarantee that this change causes no regressions. I think it should be fine though. Thanks for considering my pull request :slightly_smiling_face: 